### PR TITLE
Allow calling code to specify an explicit baud_rate for connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 __pycache__
 build
 dist
-
+venv

--- a/dsc_it100/driver.py
+++ b/dsc_it100/driver.py
@@ -86,11 +86,12 @@ class Driver(object):
         protocol.NOTIFY_PANEL_AC_RESTORED: {'type': UPDATE_GENERAL, 'ac_trouble': False},
     }
 
-    def __init__(self, serial_port, loop=None):
+    def __init__(self, serial_port, loop=None, baudrate=9600):
         """
         Constructs the DSC IT-100 driver.
 
         :param serial_port: Serial port where the IT-100 is connected to
+        :param baudrate: Optional baud rate for serial port
         :param loop: Optional event loop to use
         """
 
@@ -99,6 +100,7 @@ class Driver(object):
 
         self._loop = loop
         self._port = serial_port
+        self._baudrate = baudrate
         self._reader = None
         self._writer = None
         self._code = None
@@ -152,8 +154,9 @@ class Driver(object):
 
     @asyncio.coroutine
     def _connect(self):
+        logger.info('moo')
         self._reader, self._writer = yield from serial_asyncio.open_serial_connection(
-            loop=self._loop, url=self._port, baudrate=9600)
+            loop=self._loop, url=self._port, baudrate=self._baudrate)
 
         # Spawn coroutine for handling protocol messages.
         ensure_future(self._handle_messages(), loop=self._loop)

--- a/dsc_it100/driver.py
+++ b/dsc_it100/driver.py
@@ -154,7 +154,6 @@ class Driver(object):
 
     @asyncio.coroutine
     def _connect(self):
-        logger.info('moo')
         self._reader, self._writer = yield from serial_asyncio.open_serial_connection(
             loop=self._loop, url=self._port, baudrate=self._baudrate)
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -32,7 +32,7 @@ def handle_general_update(driver, general):
     ))
 
 loop = asyncio.get_event_loop()
-driver = dsc_it100.Driver('/dev/ttyAMA0', loop=loop, baudrate=9600)
+driver = dsc_it100.Driver('/dev/ttyUSB0', loop=loop, baudrate=9600)
 driver.set_alarm_code('1234')
 driver.handler_zone_update = handle_zone_update
 driver.handler_partition_update = handle_partition_update

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import asyncio
 
 import dsc_it100

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -32,7 +32,7 @@ def handle_general_update(driver, general):
     ))
 
 loop = asyncio.get_event_loop()
-driver = dsc_it100.Driver('/dev/ttyUSB0', loop)
+driver = dsc_it100.Driver('/dev/ttyAMA0', loop=loop, baudrate=9600)
 driver.set_alarm_code('1234')
 driver.handler_zone_update = handle_zone_update
 driver.handler_partition_update = handle_partition_update


### PR DESCRIPTION
Instead of a hard-coded baud rate, this change allows calling code to specify the configured baud rate of the IT100.  Default is 9600 if no baudrate argument is supplied allowing backward-compability with any code expecting the old behavior.